### PR TITLE
Fix updating playerContinueInBackground

### DIFF
--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -273,7 +273,7 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         }
 
         this.playerAutoDestroy.put(playerId, autoDestroy);
-        this.playerContinueInBackground.put(playerId, autoDestroy);
+        this.playerContinueInBackground.put(playerId, continueInBackground);
 
         try {
             player.prepare();


### PR DESCRIPTION
- There was wrong code where put autoDestroy to playerContinueInBackground. It mades option 'continuesToPlayInBackground' be not supported in Android.